### PR TITLE
Example of showing reconstructed shower direction

### DIFF
--- a/event-display/code.js
+++ b/event-display/code.js
@@ -130,7 +130,7 @@ function update_coincidence(coincidences) {
 
         stations.enter().append("circle")
             .attr("class", "coincidence")
-            .style("opacity", .2)
+            .style("opacity", 0.2)
             .attr("cx", function(d) { return x(station_info[d.station]) + marker_x_offset(d); })
             .attr("cy", function(d) { return y(station_info[d.station]) + marker_y_offset(d); })
             .attr("r",  function(d) { return marker_size(d) / 2; })
@@ -182,7 +182,7 @@ function update_event(events, station) {
 
         g.insert("circle", ":first-child").datum(event)
             .attr("class", "event")
-            .style("opacity", .2)
+            .style("opacity", 0.2)
             .attr("cx", function(d) { return x(station_info[d.station]) + marker_x_offset(event); })
             .attr("cy", function(d) { return y(station_info[d.station]) + marker_y_offset(event); })
             .attr("r", 0)

--- a/event-display/code.js
+++ b/event-display/code.js
@@ -99,6 +99,20 @@ function marker_size(event) {
     return size;
 }
 
+function marker_x_offset(event) {
+    /* Calculate shower start offset based on azimuth and zenith angles
+    */
+    var dx = Math.cos(event.azimuth) * 100 * event.zenith;
+    return dx;
+}
+
+function marker_y_offset(event) {
+    /* Calculate shower start offset based on azimuth and zenith angles
+    */
+    var dy = Math.sin(event.azimuth) * 100 * event.zenith;
+    return dy;
+}
+
 function update_coincidence(coincidences) {
     var c_idx = 0;
 
@@ -116,11 +130,16 @@ function update_coincidence(coincidences) {
 
         stations.enter().append("circle")
             .attr("class", "coincidence")
+            .style("opacity", .2)
+            .attr("cx", function(d) { return x(station_info[d.station]) + marker_x_offset(d); })
+            .attr("cy", function(d) { return y(station_info[d.station]) + marker_y_offset(d); })
+            .attr("r",  function(d) { return marker_size(d) / 2; })
+          .transition()
+            .duration(400)
+            .ease('poly', 2.5)
             .style("opacity", 0.7)
             .attr("cx", function(d) { return x(station_info[d.station]); })
             .attr("cy", function(d) { return y(station_info[d.station]); })
-            .attr("r", 0)
-          .transition()
             .attr("r", function(d) { return marker_size(d); })
           .transition()
             .duration(3000)
@@ -163,14 +182,20 @@ function update_event(events, station) {
 
         g.insert("circle", ":first-child").datum(event)
             .attr("class", "event")
-            .style("opacity", 0.8)
-            .attr("cx", function(d) { return x(station_info[d.station]); })
-            .attr("cy", function(d) { return y(station_info[d.station]); })
+            .style("opacity", .2)
+            .attr("cx", function(d) { return x(station_info[d.station]) + marker_x_offset(event); })
+            .attr("cy", function(d) { return y(station_info[d.station]) + marker_y_offset(event); })
             .attr("r", 0)
           .transition()
+            .duration(400)
+            .ease('poly', 0.6)
+            .style("opacity", 0.9)
+            .attr("cx", function(d) { return x(station_info[d.station]); })
+            .attr("cy", function(d) { return y(station_info[d.station]); })
             .attr("r", function(d) { return marker_size(d); })
           .transition()
             .duration(500)
+            .ease('poly', 0.6)
             .style("opacity", 0)
             .remove();
 

--- a/event-display/create_test_json.py
+++ b/event-display/create_test_json.py
@@ -2,6 +2,8 @@ import datetime
 import json
 import re
 import os
+from random import uniform
+from math import pi
 
 import tables
 
@@ -63,6 +65,8 @@ def build_coincidence_json(data, subcluster=None):
         vis_coincidence = {u: coincidence[u] for u in
                            ['timestamp', 'nanoseconds', 'ext_timestamp']}
         events = []
+        coin_direction = {'azimuth': round(uniform(-pi, pi), 4),
+                          'zenith': round(uniform(0, pi / 4), 4)}
         for s_idx, e_idx in c_index[coincidence['id']]:
             node_str = s_index[s_idx]
             station = data.get_node(node_str)
@@ -72,6 +76,7 @@ def build_coincidence_json(data, subcluster=None):
             event = {u: round(float(station_event[u]), 2)
                      if station_event[u] >= 0. else 0.
                      for u in ['n1', 'n2', 'n3', 'n4']}
+            event.update(coin_direction)
             event['station'] = station_number
             events.append(event)
         vis_coincidence['events'] = events
@@ -91,6 +96,8 @@ def build_events_json(data, station):
         output_event.update({u: round(float(event[u]), 2)
                              if event[u] >= 0. else 0.
                              for u in ['n1', 'n2', 'n3', 'n4']})
+        output_event.update({'azimuth': round(uniform(-pi, pi), 4),
+                             'zenith': round(uniform(0, pi / 4), 4)})
         output.append(output_event)
 
     return output


### PR DESCRIPTION
An example of how direction could be accounted for in the event-display.

Generate fake azimuth/zenith angles in data.
Start marker offset from station to indicate incoming direction.

Some problems;
Not perfectly clear, a lot of overlap and busy animation.
Amount of offset should also depend on zoom level.
